### PR TITLE
Fixes #2 - Markdown function error in editor

### DIFF
--- a/wp-svbtle/views/process_post.php
+++ b/wp-svbtle/views/process_post.php
@@ -1,6 +1,8 @@
 <?php
 
-require_once WPSVBTLE_PATH . "includes/markdown.php";
+if (!function_exists(Markdown)) {
+  require_once WPSVBTLE_PATH . "includes/markdown.php";
+}
 
 //ver de manejar mejor esto, con _wp_http_referer a lo mejor
 $current_page   = "index.php?page=" . $_GET['page'];


### PR DESCRIPTION
This commit should fix the error that is caused in the Admin's editor when someone already has a Markdown plugin active.
