### PR TITLE
Fix issue with iOS devices

### DIFF
--- a/wp-content/themes/svbtle/style.css
+++ b/wp-content/themes/svbtle/style.css
@@ -357,6 +357,7 @@ body.page .kudos{display: none;}
 
 @media only screen and (min-width: 35em) {
   /* Style adjustments for viewports that meet the condition */
+    header { position: relative;}
 }
 
 


### PR DESCRIPTION
zooming on content on iPhones causes the sidebar to overlap the content. This fixes that by changing the position type when viewed on the iPhone.
