### PR TITLE
Autosave

### DIFF
--- a/wp-svbtle/style.css
+++ b/wp-svbtle/style.css
@@ -272,7 +272,7 @@ a.button.new-entry{float: right; margin-top: .3em; font-size: 14px}
 input.text, textarea{border: 0; width: 500px}
 textarea{font-size: .8em; line-height: 1.4em; bottom: 100px; padding-right: 2em; position: absolute; top: 130px; padding-bottom: 200px;}
 input.text:focus, textarea:focus{outline: 0}
-#post_title{font-size: 2em; margin-top: 1.6em; font-weight: bold;}
+#title{font-size: 2em; margin-top: 1.6em; font-weight: bold;}
 
 .wps-notice{width: 80%; margin: auto; position: absolute; left: 10%;}
 

--- a/wp-svbtle/views/edit.php
+++ b/wp-svbtle/views/edit.php
@@ -3,12 +3,39 @@
 Template Name: New Post
 */
 // process the collected data
-require_once WPSVBTLE_PATH . 'views/process_post.php'; 
+require_once WPSVBTLE_PATH . 'views/process_post.php';
+
+//wp_enqueue_script('autosave');
+wp_enqueue_script('autosave-dev','/wp-includes/js/autosave.dev.js', array('schedule', 'wp-ajax-response'), '1.0', 1 );
+	wp_localize_script( 'autosave-dev', 'autosaveL10n', array(
+		'autosaveInterval' => AUTOSAVE_INTERVAL,
+		'savingText' => __('Saving Draft&#8230;'),
+		'saveAlert' => __('The changes you made will be lost if you navigate away from this page.')
+	) );
+
+//wp_just_in_time_script_localization();
 
 nocache_headers();
 include('header.php');
 ?>
-<form action="" method="post" enctype="multipart/form-data">
+
+<script type="text/javascript">
+addLoadEvent = function(func){if(typeof jQuery!="undefined")jQuery(document).ready(func);else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+var userSettings = {
+		'url': '<?php echo SITECOOKIEPATH; ?>',
+		'uid': '<?php if ( ! isset($current_user) ) $current_user = wp_get_current_user(); echo $current_user->ID; ?>',
+		'time':'<?php echo time() ?>'
+	},
+	ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
+	pagenow = '<?php echo $current_screen->id; ?>',
+	typenow = '<?php echo $current_screen->post_type; ?>',
+	adminpage = '<?php echo $admin_body_class; ?>',
+	thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
+	decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
+	isRtl = <?php echo (int) is_rtl(); ?>;
+</script>
+
+<form action="" method="post" enctype="multipart/form-data" id="post">
 	<?php if ($err != ""): ?>
 		<?php echo "<p class='wps-notice'>".$err."</p>" ?>
 	<?php elseif ($_GET['success'] == "success"): ?>
@@ -22,19 +49,20 @@ include('header.php');
 		<?php if (is_user_logged_in()): // checking weather or not the user has logged in.?>
 			<?php if(isset($post_id)): ?>
 				<input type="hidden" name="action" value="edit" />
-				<input type="hidden" name="id" value="<?php echo $post_id; ?>" />
+				<input type="hidden" name="id" id="post_ID" value="<?php echo $post_id; ?>" />
 				<?php wp_nonce_field( 'manage-post' ); ?>
+				<?php wp_nonce_field( 'autosave', 'autosavenonce', false ); ?>
 			<?php else: ?>
 				<input type="hidden" name="action" value="post" />
 				<?php wp_nonce_field( 'new-post' ); ?>
 			<?php endif; ?>
 
 			<p>
-				<input type="text" id="post_title" class="text" name="post_title" value="<?php echo $post_title;?>" placeholder="Title Here" size="60" tabindex="1"/>
+				<input type="text" id="title" class="text" name="post_title" value="<?php echo $post_title;?>" placeholder="Title Here" size="60" tabindex="1"/>
 			</p>
 
 			<p>
-				<textarea name="post_content" id="post_content" placeholder="Write post here"  tabindex="2"><?php echo $post_content ?></textarea>
+				<textarea name="content" id="content" placeholder="Write post here"  tabindex="2"><?php echo $post_content ?></textarea>
 			</p>
 
 		<?php else: ?>

--- a/wp-svbtle/views/edit.php
+++ b/wp-svbtle/views/edit.php
@@ -5,15 +5,10 @@ Template Name: New Post
 // process the collected data
 require_once WPSVBTLE_PATH . 'views/process_post.php';
 
-//wp_enqueue_script('autosave');
-wp_enqueue_script('autosave-dev','/wp-includes/js/autosave.dev.js', array('schedule', 'wp-ajax-response'), '1.0', 1 );
-	wp_localize_script( 'autosave-dev', 'autosaveL10n', array(
-		'autosaveInterval' => AUTOSAVE_INTERVAL,
-		'savingText' => __('Saving Draft&#8230;'),
-		'saveAlert' => __('The changes you made will be lost if you navigate away from this page.')
-	) );
-
-//wp_just_in_time_script_localization();
+// get scripts and localization for autosave
+// script after include(header) is for ajaxurl
+wp_enqueue_script('autosave');
+wp_just_in_time_script_localization();
 
 nocache_headers();
 include('header.php');
@@ -26,13 +21,7 @@ var userSettings = {
 		'uid': '<?php if ( ! isset($current_user) ) $current_user = wp_get_current_user(); echo $current_user->ID; ?>',
 		'time':'<?php echo time() ?>'
 	},
-	ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
-	pagenow = '<?php echo $current_screen->id; ?>',
-	typenow = '<?php echo $current_screen->post_type; ?>',
-	adminpage = '<?php echo $admin_body_class; ?>',
-	thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
-	decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
-	isRtl = <?php echo (int) is_rtl(); ?>;
+	ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>';
 </script>
 
 <form action="" method="post" enctype="multipart/form-data" id="post">

--- a/wp-svbtle/views/edit.php
+++ b/wp-svbtle/views/edit.php
@@ -51,7 +51,7 @@ var userSettings = {
 			</p>
 
 			<p>
-				<textarea name="content" id="content" placeholder="Write post here"  tabindex="2"><?php echo $post_content ?></textarea>
+				<textarea name="post_content" id="content" placeholder="Write post here"  tabindex="2"><?php echo $post_content ?></textarea>
 			</p>
 
 		<?php else: ?>

--- a/wp-svbtle/views/footer.php
+++ b/wp-svbtle/views/footer.php
@@ -1,2 +1,3 @@
+<?php do_action('admin_print_footer_scripts'); ?>
 </body>
 </html>


### PR DESCRIPTION
Hello again,

I've been hacking around and I believe I have autosave working legitimately - my commits might not be well organized, but the diff should be clearer.

I had to change some IDs around for autosave.js, and add in admin footer scripts. Possible issues include strange scripts being printed in admin footer from other plugins, resulting in JS errors (although it shouldn't affect autosave... I hope.).

Also, during certain saving situations, p tags were exposed to the user. I think this happens when autosave saves the post, and wp-svbtle's save button isn't hit, creating the markdown metadata without the p tags. We could strip tags from the displayed content in the textarea if it's an issue.

If you need anything from me, please let me know.

Best,
Andrew Freeman
