### PR TITLE
Svbtle-style 404 redirection

### DIFF
--- a/wp-content/themes/svbtle/404.php
+++ b/wp-content/themes/svbtle/404.php
@@ -7,14 +7,5 @@
  * @since Boilerplate 1.0
  */
 
-get_header(); ?>
-			<article id="post-0" class="post error404 not-found" role="main">
-				<h1><?php _e( 'Not Found', 'boilerplate' ); ?></h1>
-				<p><?php _e( 'Apologies, but the page you requested could not be found. Perhaps searching will help.', 'boilerplate' ); ?></p>
-				<?php get_search_form(); ?>
-				<script>
-					// focus on search field after it has loaded
-					document.getElementById('s') && document.getElementById('s').focus();
-				</script>
-			</article>
-<?php get_footer(); ?>
+wp_redirect(get_bloginfo('wpurl'),302);
+exit;

--- a/wp-content/themes/svbtle/404.php
+++ b/wp-content/themes/svbtle/404.php
@@ -7,5 +7,5 @@
  * @since Boilerplate 1.0
  */
 
-wp_redirect(get_bloginfo('wpurl'),302);
+wp_redirect(get_bloginfo('url').'?not_found=1',302);
 exit;

--- a/wp-content/themes/svbtle/header.php
+++ b/wp-content/themes/svbtle/header.php
@@ -116,3 +116,7 @@
 		</header>
 		
 		<section id="river" role="main">
+        
+        <?php if ($_GET['not_found']): ?>
+        <div id="notice"><span>:(</span><br><br>Not found.</div>
+        <?php endif; ?>


### PR DESCRIPTION
Svbtle redirects to homepage with a notice. I told about this in #76. (meanwhile the notice has slightly changed, see [here](http://i.imgur.com/Mziik.png).)

I made `404.php` to redirect to `blog_url/?not_found=1` and in `header.php` showed this notice according to URL parameter. It worked good on me. This is also SEO-friendlier, handles 404s with 302s. You can see an example on [my blog](http://ahmetalpbalkan.com/blog/some-404). Please merge this.

**NOTE:** Svbtle also runs javascript to remove `?not_found=1` parameter after the document is loaded, I didn't implement it  because I believe we don't have any JS file yet. (maybe you can) It removes search form in 404 page (which Ricardo created), but hey, if we are on the track of original svbtle implementation, this is a step.
