### PR TITLE
Update wp-content/themes/svbtle/header.php

### DIFF
--- a/wp-content/themes/svbtle/header.php
+++ b/wp-content/themes/svbtle/header.php
@@ -117,6 +117,6 @@
 		
 		<section id="river" role="main">
         
-        <?php if ($_GET['not_found']): ?>
+        <?php if (isset($_GET['not_found'])): ?>
         <div id="notice"><span>:(</span><br><br>Not found.</div>
         <?php endif; ?>


### PR DESCRIPTION
Gets rid of annoying warning when DEBUG mode and warnings are enabled in Wordpress.
