### PR TITLE
Fix for varnish

### DIFF
--- a/wp-content/themes/svbtle/functions.php
+++ b/wp-content/themes/svbtle/functions.php
@@ -491,7 +491,7 @@ function add_items($admin_bar)
     $args = array(
             'id'    => 'wp-svbtle-editor',
             'title' => 'wp-svbtle editor',
-            'href'  => get_bloginfo('url') . '/wp-svbtle',
+            'href'  => get_bloginfo('url') . '/wp-svbtle/',
             'meta'  => array('title' => __('wp-svbtle editor'))
             );
  


### PR DESCRIPTION
Without the trailing slashes, the editor cannot be accessed in a varnish environment
