### PR TITLE
Don't skew images with embedded sizes in posts

### DIFF
--- a/wp-content/themes/svbtle/style.css
+++ b/wp-content/themes/svbtle/style.css
@@ -122,7 +122,7 @@ ol.commentlist li.comment.byuser #respond .form-submit{margin-left: 0}
 article.post {overflow: visible}
 
 /* Don't skew images with embedded sizes in posts */
-article img{height: 100%}
+article img{height:100%; width:100%}
 
 #respond .comment-subscription-form{margin-bottom: 10px}
 

--- a/wp-content/themes/svbtle/style.css
+++ b/wp-content/themes/svbtle/style.css
@@ -121,6 +121,9 @@ ol.commentlist li.comment.byuser #respond .form-submit{margin-left: 0}
 
 article.post {overflow: visible}
 
+/* Don't skew images with embedded sizes in posts */
+article img{height: 100%}
+
 #respond .comment-subscription-form{margin-bottom: 10px}
 
 


### PR DESCRIPTION
Images like this

```
<img width="1200" height="720" alt="bar" src="http://foo>
```

get skewed (not proportionally scaled), except in the responsive layout. 

This is fixed with:

```
article img{height:100%; width:100%}
```
