### PR TITLE
Fix WSOD in child themes

### DIFF
--- a/wp-content/themes/svbtle/functions.php
+++ b/wp-content/themes/svbtle/functions.php
@@ -271,7 +271,7 @@ function register_custom_menu() {
 	register_nav_menu( 'primary', __( 'Svbtle Menu') );
 }
 
-require_once ( get_stylesheet_directory() . '/theme-options.php' );
+require_once ( get_template_directory() . '/theme-options.php' );
 
 
 


### PR DESCRIPTION
use get_template_directory instead of get_stylesheet directory when looking for the parent theme's theme-options.php file.
